### PR TITLE
Handle multiple sequential function calls

### DIFF
--- a/lib/handleChatting.js
+++ b/lib/handleChatting.js
@@ -39,8 +39,9 @@ export async function handleChatting(userRequest, userMetaData){
         // Execute functions if any were returned
         if(response.functionUsed && response.functionUsed.length > 0){
             try {
-                const functionResponse = await executeFunction(response.functionUsed, userMetaData, response.originalUserInput);
-                responseToMainAsistant.functionResponse.push(functionResponse);
+                const functionResponses = await executeFunction(response.functionUsed, userMetaData, response.originalUserInput);
+                // Collect all results returned from executeFunction
+                responseToMainAsistant.functionResponse.push(...functionResponses);
             } catch (functionError) {
                 console.error("Error executing function:", functionError);
                 // Continue processing even if function execution fails
@@ -159,25 +160,41 @@ function formatResponseToMainAssistant(responseToMainAsistant){
 }
 
 async function executeFunction(functionCalls, userMetaData, originalUserRequest){
-    for(const functionCall of functionCalls){
-        console.log("functionCall:",functionCall);
-        switch(functionCall.name){
+    const results = [];
+    for (const functionCall of functionCalls) {
+        console.log("functionCall:", functionCall);
+        switch (functionCall.name) {
             case "get_weather_forecast":
-                return await executeWeatherForecast({...functionCall.args,latitude:userMetaData.latitude,longitude:userMetaData.longitude});
+                results.push(await executeWeatherForecast({
+                    ...functionCall.args,
+                    latitude: userMetaData.latitude,
+                    longitude: userMetaData.longitude
+                }));
+                break;
             case "add_schedule_event":
-                return await executeAddScheduleEvent({...functionCall.args,userId:userMetaData.id});
+                results.push(await executeAddScheduleEvent({
+                    ...functionCall.args,
+                    userId: userMetaData.id
+                }));
+                break;
             case "get_schedule_events":
                 // The entire functionCall.args should now be { event_queries: [...] }
-                return await executeGetScheduleEvents({userId: userMetaData.id, ...functionCall.args});
+                results.push(await executeGetScheduleEvents({
+                    userId: userMetaData.id,
+                    ...functionCall.args
+                }));
+                break;
             case "use_google_search":
-                return await executeGoogleSearch(functionCall.args);
+                results.push(await executeGoogleSearch(functionCall.args));
+                break;
             case "recommend_schedule":
-                return await executeRecommendSchedule(functionCall.args, userMetaData, originalUserRequest);
+                results.push(await executeRecommendSchedule(functionCall.args, userMetaData, originalUserRequest));
+                break;
             default:
                 throw new Error(`Invalid function name: ${functionCall.name}`);
         }
     }
-    
+    return results;
 }
 
 async function executeWeatherForecast({latitude,longitude,cityName=null,days=1}){


### PR DESCRIPTION
## Summary
- allow multiple function calls in `executeFunction`
- push all function results onto `functionResponse` in `handleChatting`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684066fda614832ca7436e69c74920c0