### PR TITLE
Fix weather service query encoding and https

### DIFF
--- a/lib/tools/weatherService.js
+++ b/lib/tools/weatherService.js
@@ -20,9 +20,10 @@ export async function weatherService(latitude, longitude, cityName=null,days = 1
   try {
     // Validate days parameter (1-3)
     let apiDays = Math.max(1, Math.min(parseInt(days, 10) || 1, 3));
-    let url = `http://api.weatherapi.com/v1/forecast.json?key=${WEATHER_API_KEY}&q=${latitude},${longitude}&days=${apiDays}`;
+    const baseUrl = "https://api.weatherapi.com/v1/forecast.json";
+    let url = `${baseUrl}?key=${WEATHER_API_KEY}&q=${latitude},${longitude}&days=${apiDays}`;
     if(cityName){
-      url = `http://api.weatherapi.com/v1/forecast.json?key=${WEATHER_API_KEY}&q=${cityName}&days=${apiDays}`;
+      url = `${baseUrl}?key=${WEATHER_API_KEY}&q=${encodeURIComponent(cityName)}&days=${apiDays}`;
     }
 
     const response = await fetch(
@@ -36,5 +37,6 @@ export async function weatherService(latitude, longitude, cityName=null,days = 1
     return summarizedData;
   } catch (error) {
     console.error(error);
+    throw error;
   }
 }


### PR DESCRIPTION
## Summary
- use https endpoints in weatherService
- encode city name query parameters
- rethrow errors so callers can handle failures

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68406701eb84832c909a26f5d75c0c1a