### PR TITLE
Modify control agent prompt behavior

### DIFF
--- a/lib/ai/controlAgent.js
+++ b/lib/ai/controlAgent.js
@@ -10,10 +10,11 @@ export async function controlAgent(userRequest,chatHistory,userProfileInfo) {
   const prompt = getControlAgentPrompt(userRequest,chatHistory,userProfileInfo);
   
   let finalResponse = {
-    functionUsed:[],
+    functionUsed: [],
     originalUserInput: userRequest,
-    googleSearchQuery:null
-  }
+    googleSearchQuery: null,
+    instructionFromControlAgent: ""
+  };
 
   try {
     const response = await ai.models.generateContent({
@@ -37,6 +38,7 @@ export async function controlAgent(userRequest,chatHistory,userProfileInfo) {
         finalResponse.functionUsed = response.functionCalls;
     }
     finalResponse.googleSearchQuery = response.functionCalls.find((funcCall) => funcCall.name === "use_google_search")?.args?.query;
+    finalResponse.instructionFromControlAgent = response.text;
     return finalResponse;
   } catch (error) {
     throw new Error(error);

--- a/lib/ai/mainAgent.js
+++ b/lib/ai/mainAgent.js
@@ -19,11 +19,11 @@ const ErrorTypes = {
 /**
  * Enhanced main agent function with improved error handling, context management, and personalization
  */
-export async function mainAgent(userRequest,chatHistory,userProfile,functionResponses){
+export async function mainAgent(userRequest,chatHistory,userProfile,functionResponses,instructionFromControlAgent=""){ 
     let retries = 0;
     let lastError = null;
     
-    const prompt = getMainAgentPrompt(userRequest,chatHistory,userProfile,functionResponses);
+    const prompt = getMainAgentPrompt(userRequest,chatHistory,userProfile,functionResponses,instructionFromControlAgent);
     
     while (retries < MAX_RETRIES) {
         try {

--- a/lib/handleChatting.js
+++ b/lib/handleChatting.js
@@ -36,6 +36,7 @@ export async function handleChatting(userRequest, userMetaData){
         // Get function calls from control agent
         const response = await controlAgent(userRequest, userMetaData.chatHistory,userMetaData.userProfileInfo);
         let functionResponses = [];
+        const instructionFromControlAgent = response.instructionFromControlAgent;
         
         // Execute functions if any were returned
         if(response.functionUsed && response.functionUsed.length > 0){
@@ -75,7 +76,7 @@ export async function handleChatting(userRequest, userMetaData){
         // console.log("Result prompt for main agent:",formattedResponseToMainAsistant);
 
         // Call the main agent with the entire formatted string rather than an object
-        const mainAgentResponse = await mainAgent(userRequest,userMetaData.chatHistory,userMetaData.userProfileInfo,functionResponses);
+        const mainAgentResponse = await mainAgent(userRequest,userMetaData.chatHistory,userMetaData.userProfileInfo,functionResponses,instructionFromControlAgent);
         
         // Add performance metrics
         const executionTime = Date.now() - startTime;

--- a/lib/tools/getPrompt.js
+++ b/lib/tools/getPrompt.js
@@ -21,6 +21,8 @@ export function getControlAgentPrompt(
         5. When recommending or adding a schedule, first use 'get_schedule_events' to retrieve the user's schedule for approximately one week before and after the target date, and adjust the new schedule accordingly to avoid conflicts and fit the user's availability.
         6. Use today's date ${new Date().toISOString().split("T")[0]} as the reference date.
         7. Use current time ${new Date().toISOString().split("T")[1]} as the reference time.
+        8. If the user's message is simply a greeting or attention call (e.g., "안녕", "안녕하세요", "hey", "야"), do not call any function. Instead, instruct the main agent to reply with a warm greeting like "안녕하세요! 저는 Solus에요" and, if schedule information is available, mention today's agenda and ask how you can help (for example: "오늘 일정이 ~~ 인데 ~~ 해볼까요?").
+        9. Avoid using 'use_google_search' for straightforward questions you can answer with general knowledge. Use it only when the user explicitly requests a web search or seeks information you cannot answer directly.
 
         Proper function selection:
             - For Weather related qeustions' context, and the requested days are less than or equal to 3 days, use 'get_weather_forecast'.
@@ -28,7 +30,7 @@ export function getControlAgentPrompt(
             - For Reporting schedule related qeustions' context, use 'get_schedule_events'.
             - For Adding schedule related qeustions' context, use 'add_schedule_event'.
             - For Suggesting schedule related qeustions' context, use 'recommend_schedule'.
-            - For other qeustions' context, use 'use_google_search' or don't use any function.
+            - For other qeustions' context, answer directly without calling a function when possible. Only use 'use_google_search' if the user explicitly requests a web search or if necessary information is unavailable otherwise.
 
     ---------------------
 
@@ -40,7 +42,8 @@ export function getMainAgentPrompt( //check codex
     userRequest,
     conversationContext,
     userProfile,
-    functionResponses = []
+    functionResponses = [],
+    instructionFromControlAgent = ""
 ) {
     return `
     You are a super artificial general assistant, reminiscent of JARVIS from Iron Man. You consolidate outputs from multiple internal tools and present them to the user. Make full use of the provided conversation context and user profile to keep continuity and avoid repeating previous information.
@@ -95,6 +98,9 @@ export function getMainAgentPrompt( //check codex
             <p>Would you like me to add this to your calendar?</p>,
     
     ---------------------
+
+    Instruction from control agent:
+        ${instructionFromControlAgent}
 
     Function responses:
         ${functionResponses.map((response) => {


### PR DESCRIPTION
## Summary
- adjust `getControlAgentPrompt` greeting instruction
- rename `controlAgentText` to `instructionFromControlAgent`
- propagate renamed field through the main agent pipeline

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846b06d16bc832cbaf5cd48c76b6e1b