### PR TITLE
Add survey saving endpoint

### DIFF
--- a/DB/users.js
+++ b/DB/users.js
@@ -36,3 +36,14 @@ export async function getUserProfileInfo(id) {
     return { success: false };
   }
 }
+
+export async function saveSurveyResult({ id, likes, location, name, personalGoal, profileImage }) {
+  const query = `UPDATE users SET likes = ?, location = ?, name = ?, personal_goal = ?, profile_image = ? WHERE id = ?`;
+  try {
+    const [result] = await pool.execute(query, [JSON.stringify(likes), location, name, personalGoal, profileImage, id]);
+    return { success: true, result };
+  } catch (err) {
+    console.error("Saving survey result failed:", err);
+    return { success: false };
+  }
+}

--- a/routes/user.js
+++ b/routes/user.js
@@ -1,5 +1,5 @@
 import express from "express";
-import { getUserProfileInfo } from "../DB/users.js";
+import { getUserProfileInfo, saveSurveyResult } from "../DB/users.js";
 import { verifyJWT } from "../lib/token.js";
 
 const router = express.Router();
@@ -19,6 +19,35 @@ router.get("/get_profile", async (req, res, next) => {
       });
     } else {
       throw new Error("Gettting profileImage failed.");
+    }
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post("/save_survey_result", async (req, res, next) => {
+  try {
+    const accessToken = req.headers.authorization?.split(" ")[1];
+    if (!accessToken) {
+      throw new Error("Access token not found.");
+    }
+    const { id } = verifyJWT(accessToken);
+
+    const { likes, location, name, personalGoal, profileImage } = req.body;
+
+    const { success } = await saveSurveyResult({
+      id,
+      likes,
+      location,
+      name,
+      personalGoal,
+      profileImage,
+    });
+
+    if (success) {
+      res.status(200).json({ message: "Survey result saved successfully." });
+    } else {
+      throw new Error("Failed to save survey result.");
     }
   } catch (err) {
     next(err);


### PR DESCRIPTION
## Summary
- implement DB helper to store survey results
- expose POST /user/save_survey_result to persist survey data

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849b769332c832c8b4ff733fb1f92eb