### PR TITLE
Enhance search prompt and HTML formatting

### DIFF
--- a/lib/tools/formatter.js
+++ b/lib/tools/formatter.js
@@ -63,9 +63,22 @@ export function scheduleRecommendationsFormatter(recommendations){
 }
 
 export function googleSearchFormatter(response){
-    return `
+    try {
+        const data = typeof response === 'string' ? JSON.parse(response) : response;
+        const links = Array.isArray(data.relatedLinks)
+            ? data.relatedLinks.map((link, i) => `${i + 1}. ${link.title} - ${link.url}`).join("\n")
+            : "";
+        return `
+        Response from use_google_search:
+            searchResult: ${data.searchResult}
+            relatedLinks:
+                ${links}
+        `;
+    } catch (err) {
+        return `
         Response from use_google_search:
             ${response}
-    `
+        `;
+    }
 }
 

--- a/lib/tools/getPrompt.js
+++ b/lib/tools/getPrompt.js
@@ -70,10 +70,10 @@ export function getMainAgentPrompt( //check codex
         12. If you detect a significant change in topic, acknowledge it smoothly before transitioning.
         13. When formatting your 'response' text:
             * You ARE allowed to use HTML elements to improve structure and readability.
-            * Allowed HTML tags: <p>, <ul>, <ol>, <li>, <b>, <strong>, <i>, <em>, <br>, <h1> to <h3>.
+            * Allowed HTML tags: <p>, <ul>, <ol>, <li>, <b>, <strong>, <i>, <em>, <br>, <h1> to <h3>, <a>.
             * Each major section should start with an <h2> or <h3> heading.
-            * Between sections, insert an empty line (<br> or extra spacing) to make it visually clear.
-            * Inside each section, use <p> for paragraphs, and <ul><li> for lists of points.
+            * Between sections, insert an empty line (<br> or extra spacing) to make it visually clear. Leave a couple of blank lines when appropriate to clearly separate Heading, Body, and other sections.
+            * Inside each section, use <p> for paragraphs, and <ul><li> for lists of points. Use <a> tags to embed any web links.
             * The order of sections depends on the data, but a typical flow can be:
                 - <h2>Overall Summary</h2>
                 - <h2>Key Insights</h2>
@@ -217,7 +217,9 @@ export function getScheudleRecommederPrompt(userRequest,retrievedSchedules,selec
 export function getGoogleSearchPrompt(userRequest){
     return `
     You are a intelligent google search assistant. You must search the web for the user's query.
-    
+
+    Provide a concise search result summary and include a few relevant links with titles.
+
     ---------------------
     
     User request: ${userRequest}
@@ -227,7 +229,13 @@ export function getGoogleSearchPrompt(userRequest){
     Output Format:
       {
         "searchResult": "string",
-      }    
+        "relatedLinks": [
+            {
+                "title": "string",
+                "url": "string"
+            },...
+        ]
+      }
     `
 }
 


### PR DESCRIPTION
## Summary
- add <a> tag usage and spacing guidance for main agent HTML output
- ask google search agent to return related links
- parse and format search results with links

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684aeee10150832ca9cf1b26fd55e2e8