### PR TITLE
Implement schedule completion selection

### DIFF
--- a/lib/ai/scheduleCompletionIdentifier.js
+++ b/lib/ai/scheduleCompletionIdentifier.js
@@ -1,0 +1,25 @@
+import "dotenv/config";
+import { GoogleGenAI } from "@google/genai";
+import { getScheduleCompletionPrompt } from "../tools/getPrompt.js";
+
+const ai = new GoogleGenAI({ apiKey: process.env.GOOGLE_GEMINI_API_KEY });
+
+export async function identifyScheduleToComplete(userQuery, schedules) {
+  try {
+    const prompt = getScheduleCompletionPrompt(userQuery, schedules);
+    const response = await ai.models.generateContent({
+      model: process.env.GEMINI_MODEL,
+      contents: [prompt],
+      config: { responseMimeType: "application/json" }
+    });
+    const jsonRes = response.text;
+    return JSON.parse(jsonRes);
+  } catch (err) {
+    console.error("Error in identifyScheduleToComplete:", err);
+    return {
+      failedToFindExactSchedule: true,
+      id: null,
+      response: "I couldn't determine which schedule to mark complete."
+    };
+  }
+}

--- a/lib/handleChatting.js
+++ b/lib/handleChatting.js
@@ -3,6 +3,7 @@ import {googleSearchAgent} from "./ai/googleSearchAgent.js";
 import { mainAgent } from "./ai/mainAgent.js";
 import { getScheduleRecommendations } from "./ai/scheduleRecommender.js";
 import { weatherDataFormatter, googleSearchFormatter, scheduleRecommendationsFormatter,getScheduleEventsFormatter,addScheduleEventFormatter, updateUserProfileFormatter, completeScheduleEventFormatter } from "./tools/formatter.js";
+import { identifyScheduleToComplete } from "./ai/scheduleCompletionIdentifier.js";
 
 import { weatherService } from "./tools/weatherService.js";
 import {addSchedule, getEvents, completeEvent} from "../DB/schedule.js";
@@ -127,7 +128,7 @@ async function executeFunction(functionCalls, userMetaData, originalUserRequest)
                 }));
                 break;
             case "complete_schedule_event":
-                results.push(await executeCompleteScheduleEvent(functionCall.args));
+                results.push(await executeCompleteScheduleEvent(functionCall.args, userMetaData));
                 break;
             case "use_google_search":
                 results.push(await executeGoogleSearch(functionCall.args));
@@ -319,19 +320,45 @@ async function executeGoogleSearch({ query }) {
     }
 }
 
-async function executeCompleteScheduleEvent({ event_id }) {
+async function executeCompleteScheduleEvent({ user_query, event_queries }, userMetaData) {
     try {
-        const result = await completeEvent(event_id);
-        const formatted = completeScheduleEventFormatter(event_id);
+        let allEvents = [];
+        if (event_queries && Array.isArray(event_queries)) {
+            for (const query of event_queries) {
+                const [year, month, day] = query.date.split("-");
+                const events = await getEvents(
+                    userMetaData.id,
+                    year,
+                    month,
+                    day,
+                    query.time_condition,
+                    query.time_reference,
+                    query.time_reference_end
+                );
+                if (events && events.length > 0) {
+                    allEvents.push(...events);
+                }
+            }
+        }
+        const identifyRes = await identifyScheduleToComplete(user_query, allEvents);
+        if (!identifyRes.failedToFindExactSchedule && identifyRes.id) {
+            await completeEvent(identifyRes.id);
+        }
+        const formatted = completeScheduleEventFormatter({
+            id: identifyRes.id,
+            failedToFindExactSchedule: identifyRes.failedToFindExactSchedule,
+            response: identifyRes.response
+        });
         return {
             name: "complete_schedule_event",
-            summary: `Marked event ${event_id} as complete`,
+            summary: identifyRes.response,
             formattedData: formatted
         };
     } catch (err) {
         throw new Error(`Error occurred while executing complete_schedule_event: ${err.message}`);
     }
 }
+
 
 async function executeUpdateUserProfile(args, userId) {
     try {

--- a/lib/tools/formatter.js
+++ b/lib/tools/formatter.js
@@ -82,10 +82,12 @@ export function googleSearchFormatter(response){
     }
 }
 
-export function completeScheduleEventFormatter(id){
+export function completeScheduleEventFormatter({id, failedToFindExactSchedule, response}){
     return `
         Response from complete_schedule_event:
             completed_event_id: ${id}
+            failed_to_find_exact_schedule: ${failedToFindExactSchedule}
+            message: ${response}
     `
 }
 

--- a/lib/tools/getPrompt.js
+++ b/lib/tools/getPrompt.js
@@ -25,7 +25,7 @@ export function getControlAgentPrompt(
         9. Avoid using 'use_google_search' for straightforward questions you can answer with general knowledge. Use it only when the user explicitly requests a web search or seeks information you cannot answer directly.
         10. If new user preference information is found in the conversation, call 'update_user_profile' with the changed fields. The 'likes' field should follow the [[categoryName,[item1,item2]],...] structure.
         11. When the user asks for something outside the assistant's capabilities or impossible to perform, instruct the main agent to politely explain the limitation and offer an alternative approach instead of calling a function.
-        12. When a user reports finishing a task or requests to mark an event as complete, first call 'get_schedule_events' to fetch events for roughly a week around the relevant date. Identify the best matching event ID. If the match is unclear, ask the user for confirmation in their language and provide the likely event ID. Only call 'complete_schedule_event' after the user confirms.
+        12. When a user wants to mark an event as complete, call 'complete_schedule_event' with the user's request text and an appropriate event_queries array covering about a week around the mentioned date. The function will determine the best event and indicate if confirmation is needed.
 
         Proper function selection:
             - For Weather related qeustions' context, and the requested days are less than or equal to 3 days, use 'get_weather_forecast'.
@@ -101,6 +101,7 @@ export function getMainAgentPrompt( //check codex
             <h3><b>Next Step</b></h3>
             <p>Would you like me to add this to your calendar?</p>,
         14. If you detect new user preferences, update the 'new_user_preference' field in the output format.
+        15. If any function response from 'complete_schedule_event' indicates 'failed_to_find_exact_schedule: true', ask the user which event should be marked complete based on the provided message.
         
     
     ---------------------
@@ -288,4 +289,32 @@ function formatLikes(likes) {
   } catch (e) {
     return String(likes);
   }
+}
+
+export function getScheduleCompletionPrompt(userQuery, schedules){
+    return `
+      You are a smart assistant that identifies which schedule the user wants to mark as complete.
+      If the correct schedule cannot be determined, set failedToFindExactSchedule to true and give a short response asking for clarification.
+
+      ---------------------
+
+      User Query: ${userQuery}
+
+      ---------------------
+
+      Schedules:
+      ${schedules.map((s,index)=>{
+        return `
+            ${s.id}. ${s.year}-${s.month}-${s.day} ${s.start_time || ''}${s.end_time ? '-' + s.end_time : ''} ${s.title} - ${s.description}
+        `;}).join("\n")}
+
+      ---------------------
+
+      Output Format:
+        {
+          "failedToFindExactSchedule": false,
+          "id": number,
+          "response": "string"
+        }
+    `;
 }

--- a/lib/tools/toolsConfig.js
+++ b/lib/tools/toolsConfig.js
@@ -133,14 +133,30 @@ const recommendScheduleConfig = {
     const completeScheduleEventConfig = {
       name: "complete_schedule_event",
       description: `
-      Mark a schedule event as completed using its ID. Use this only after retrieving the event list and confirming with the user which event to mark done.
+      Identify and mark a schedule event as completed based on the user's request. 
+      Provide the original user query and an array of event_queries to fetch candidate events. 
+      If the correct event is unclear, the function will return failedToFindExactSchedule as true.
       `,
       parameters: {
         type: Type.OBJECT,
         properties: {
-          event_id: { type: Type.STRING }
+          user_query: { type: Type.STRING },
+          event_queries: {
+            type: Type.ARRAY,
+            description: "Array of query objects for potential dates/times.",
+            items: {
+              type: Type.OBJECT,
+              properties: {
+                date: { type: Type.STRING },
+                time_condition: { type: Type.STRING },
+                time_reference: { type: Type.STRING },
+                time_reference_end: { type: Type.STRING }
+              },
+              required: ["date"]
+            }
+          }
         },
-        required: ["event_id"]
+        required: ["user_query", "event_queries"]
       }
     };
 


### PR DESCRIPTION
## Summary
- add a model to select the schedule to complete
- revise complete_schedule_event workflow to find best event via new model
- store message and failure flag in formatter output
- update tool config and control-agent prompt for new behaviour
- refine bullet in main-agent prompt

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684beaf11a50832c9f892b2a61208bfd