### PR TITLE
Add general question handler and update prompts

### DIFF
--- a/lib/handleChatting.js
+++ b/lib/handleChatting.js
@@ -139,6 +139,9 @@ async function executeFunction(functionCalls, userMetaData, originalUserRequest)
             case "update_user_profile":
                 results.push(await executeUpdateUserProfile(functionCall.args, userMetaData.id));
                 break;
+            case "answer_general_question":
+                results.push(await executeAnswerGeneralQuestion(functionCall.args));
+                break;
             default:
                 throw new Error(`Invalid function name: ${functionCall.name}`);
         }
@@ -373,5 +376,13 @@ async function executeUpdateUserProfile(args, userId) {
     } catch (err) {
         throw new Error(`Error occurred while executing update_user_profile: ${err.message}`);
     }
+}
+
+async function executeAnswerGeneralQuestion({ instructionForMainAgent }) {
+    return {
+        name: "answer_general_question",
+        summary: instructionForMainAgent,
+        formattedData: instructionForMainAgent
+    };
 }
 

--- a/lib/tools/getPrompt.js
+++ b/lib/tools/getPrompt.js
@@ -16,12 +16,12 @@ export function getControlAgentPrompt(
     Instructions:
         1. Prioritize the provided conversation context and user profile when determining which functions to use.
         2. When multiple functions are required, list them all in the order they should be executed.
-        3. If you can answer without using any function, do not use any function.
+        3. If you can answer without using any specialized tool, call 'answer_general_question' with clear instructions for how the main agent should reply.
         4. Read function tools config and use it to determine which function to use.
         5. When recommending or adding a schedule, first use 'get_schedule_events' to retrieve the user's schedule for approximately one week before and after the target date, and adjust the new schedule accordingly to avoid conflicts and fit the user's availability.
         6. Use today's date ${new Date().toISOString().split("T")[0]} as the reference date.
         7. Use current time ${new Date().toISOString().split("T")[1]} as the reference time.
-        8. If the user's message is simply a greeting or attention call (e.g., "안녕", "안녕하세요", "hey", "야"), do not call any function. Instead, instruct the main agent to reply with a warm greeting like "안녕하세요! 저는 Solus에요" and, if schedule information is available, mention today's agenda and ask how you can help (for example: "오늘 일정이 ~~ 인데 ~~ 해볼까요?").
+        8. If the user's message is simply a greeting or small talk, use 'answer_general_question' and pass a friendly greeting instruction such as "안녕하세요! 저는 Solus에요". If schedule information is available, mention today's agenda and ask how you can help (for example: "오늘 일정이 ~~ 인데 ~~ 해볼까요?").
         9. Avoid using 'use_google_search' for straightforward questions you can answer with general knowledge. Use it only when the user explicitly requests a web search or seeks information you cannot answer directly.
         10. If new user preference information is found in the conversation, call 'update_user_profile' with the changed fields. The 'likes' field should follow the [[categoryName,[item1,item2]],...] structure.
         11. When the user asks for something outside the assistant's capabilities or impossible to perform, instruct the main agent to politely explain the limitation and offer an alternative approach instead of calling a function.
@@ -34,7 +34,7 @@ export function getControlAgentPrompt(
             - For Adding schedule related qeustions' context, use 'add_schedule_event'.
             - For Suggesting schedule related qeustions' context, use 'recommend_schedule'.
             - For marking a schedule as complete, use 'complete_schedule_event'.
-            - For other qeustions' context, answer directly without calling a function when possible. Only use 'use_google_search' if the user explicitly requests a web search or if necessary information is unavailable otherwise.
+            - For other qeustions' context that do not require special tools, use 'answer_general_question' with appropriate guidance for the main agent. Only use 'use_google_search' if the user explicitly requests a web search or if necessary information is unavailable otherwise.
 
     ---------------------
 

--- a/lib/tools/toolsConfig.js
+++ b/lib/tools/toolsConfig.js
@@ -38,6 +38,18 @@ export function getToolsConfig(Type){
       }
     };
 
+    const answerGeneralQuestionConfig = {
+      name: "answer_general_question",
+      description: "Use this when no other function is required. Provide a short instruction for the main agent on how to answer the user's general request or greeting.",
+      parameters: {
+        type: Type.OBJECT,
+        properties: {
+          instructionForMainAgent: { type: Type.STRING }
+        },
+        required: ["instructionForMainAgent"]
+      }
+    };
+
 
     
     const addScheduleEventConfig = {
@@ -181,6 +193,7 @@ return [
   getScheduleEventsConfig,
   completeScheduleEventConfig,
   useGoogleSearchConfig,
+  answerGeneralQuestionConfig,
   recommendScheduleConfig,
   updateUserProfileConfig
 ];


### PR DESCRIPTION
## Summary
- add `answer_general_question` tool to tools config
- guide control agent to use new tool when a specialized tool isn't needed
- support new function execution in `handleChatting`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c1b24e414832c8d774df93e4f6bd3