### PR TITLE
Add delete support for schedule completion

### DIFF
--- a/lib/ai/scheduleCompletionIdentifier.js
+++ b/lib/ai/scheduleCompletionIdentifier.js
@@ -19,7 +19,8 @@ export async function identifyScheduleToComplete(userQuery, schedules) {
     return {
       failedToFindExactSchedule: true,
       id: null,
-      response: "I couldn't determine which schedule to mark complete."
+      action: null,
+      response: "I couldn't determine which schedule to process."
     };
   }
 }

--- a/lib/handleChatting.js
+++ b/lib/handleChatting.js
@@ -2,11 +2,11 @@ import {controlAgent} from "./ai/controlAgent.js";
 import {googleSearchAgent} from "./ai/googleSearchAgent.js";
 import { mainAgent } from "./ai/mainAgent.js";
 import { getScheduleRecommendations } from "./ai/scheduleRecommender.js";
-import { weatherDataFormatter, googleSearchFormatter, scheduleRecommendationsFormatter,getScheduleEventsFormatter,addScheduleEventFormatter, updateUserProfileFormatter, completeScheduleEventFormatter } from "./tools/formatter.js";
+import { weatherDataFormatter, googleSearchFormatter, scheduleRecommendationsFormatter,getScheduleEventsFormatter,addScheduleEventFormatter, updateUserProfileFormatter, updateScheduleEventFormatter } from "./tools/formatter.js";
 import { identifyScheduleToComplete } from "./ai/scheduleCompletionIdentifier.js";
 
 import { weatherService } from "./tools/weatherService.js";
-import {addSchedule, getEvents, completeEvent} from "../DB/schedule.js";
+import {addSchedule, getEvents, completeEvent, deleteEvent} from "../DB/schedule.js";
 import { updateUserProfile } from "../DB/users.js";
 
 /**
@@ -127,8 +127,8 @@ async function executeFunction(functionCalls, userMetaData, originalUserRequest)
                     ...functionCall.args
                 }));
                 break;
-            case "complete_schedule_event":
-                results.push(await executeCompleteScheduleEvent(functionCall.args, userMetaData));
+            case "update_schedule_event":
+                results.push(await executeUpdateScheduleEvent(functionCall.args, userMetaData));
                 break;
             case "use_google_search":
                 results.push(await executeGoogleSearch(functionCall.args));
@@ -320,7 +320,7 @@ async function executeGoogleSearch({ query }) {
     }
 }
 
-async function executeCompleteScheduleEvent({ user_query, event_queries }, userMetaData) {
+async function executeUpdateScheduleEvent({ user_query, event_queries }, userMetaData) {
     try {
         let allEvents = [];
         if (event_queries && Array.isArray(event_queries)) {
@@ -343,17 +343,21 @@ async function executeCompleteScheduleEvent({ user_query, event_queries }, userM
         const identifyRes = await identifyScheduleToComplete(user_query, allEvents);
         for (const item of identifyRes) {
             if (!item.failedToFindExactSchedule && item.id) {
-                await completeEvent(item.id);
+                if (item.action === "delete") {
+                    await deleteEvent(item.id);
+                } else {
+                    await completeEvent(item.id);
+                }
             }
         }
-        const formatted = completeScheduleEventFormatter(identifyRes);
+        const formatted = updateScheduleEventFormatter(identifyRes);
         return {
-            name: "complete_schedule_event",
+            name: "update_schedule_event",
             summary: identifyRes.response,
             formattedData: formatted
         };
     } catch (err) {
-        throw new Error(`Error occurred while executing complete_schedule_event: ${err.message}`);
+        throw new Error(`Error occurred while executing update_schedule_event: ${err.message}`);
     }
 }
 

--- a/lib/tools/formatter.js
+++ b/lib/tools/formatter.js
@@ -82,13 +82,14 @@ export function googleSearchFormatter(response){
     }
 }
 
-export function completeScheduleEventFormatter(identifyRes){
+export function updateScheduleEventFormatter(identifyRes){
     return `
-        Response from complete_schedule_event:
+        Response from update_schedule_event:
           ${identifyRes.map((item,index)=>{
             return `
-                ${index+1}. 
+                ${index+1}.
                     id: ${item.id}
+                    action: ${item.action}
                     failedToFindExactSchedule: ${item.failedToFindExactSchedule}
                     response: ${item.response}`
           }).join("\n")}

--- a/lib/tools/getPrompt.js
+++ b/lib/tools/getPrompt.js
@@ -25,7 +25,7 @@ export function getControlAgentPrompt(
         9. Avoid using 'use_google_search' for straightforward questions you can answer with general knowledge. Use it only when the user explicitly requests a web search or seeks information you cannot answer directly.
         10. If new user preference information is found in the conversation, call 'update_user_profile' with the changed fields. The 'likes' field should follow the [[categoryName,[item1,item2]],...] structure.
         11. When the user asks for something outside the assistant's capabilities or impossible to perform, instruct the main agent to politely explain the limitation and offer an alternative approach instead of calling a function.
-        12. When a user wants to mark an event as complete, call 'complete_schedule_event' with the user's request text and an appropriate event_queries array covering about a week around the mentioned date. The function will determine the best event and indicate if confirmation is needed.
+        12. When a user wants to mark an event as complete or delete it, call 'update_schedule_event' with the user's request text and an appropriate event_queries array covering about a week around the mentioned date. The function will determine the best event and indicate if confirmation is needed.
 
         Proper function selection:
             - For Weather related qeustions' context, and the requested days are less than or equal to 3 days, use 'get_weather_forecast'.
@@ -33,7 +33,7 @@ export function getControlAgentPrompt(
             - For Reporting schedule related qeustions' context, use 'get_schedule_events'.
             - For Adding schedule related qeustions' context, use 'add_schedule_event'.
             - For Suggesting schedule related qeustions' context, use 'recommend_schedule'.
-            - For marking a schedule as complete, use 'complete_schedule_event'.
+            - For marking a schedule as complete or deleting it, use 'update_schedule_event'.
             - For other qeustions' context, answer directly without calling a function when possible. Only use 'use_google_search' if the user explicitly requests a web search or if necessary information is unavailable otherwise.
 
     ---------------------
@@ -101,7 +101,7 @@ export function getMainAgentPrompt( //check codex
             <h3><b>Next Step</b></h3>
             <p>Would you like me to add this to your calendar?</p>,
         14. If you detect new user preferences, update the 'new_user_preference' field in the output format.
-        15. If any function response from 'complete_schedule_event' indicates 'failed_to_find_exact_schedule: true', ask the user which event should be marked complete based on the provided message.
+        15. If any function response from 'update_schedule_event' indicates 'failed_to_find_exact_schedule: true', ask the user which event should be processed (completed or deleted) based on the provided message.
         
     
     ---------------------
@@ -293,7 +293,7 @@ function formatLikes(likes) {
 
 export function getScheduleCompletionPrompt(userQuery, schedules){
     return `
-      You are a smart assistant that identifies which schedule(s) the user wants to mark as complete.
+      You are a smart assistant that identifies which schedule(s) the user wants to mark as complete or delete.
 
       ---------------------
 
@@ -303,27 +303,28 @@ export function getScheduleCompletionPrompt(userQuery, schedules){
 
       Instructions:
         1. Use today's date (${new Date().toISOString().split("T")[0]}) as reference when the user says "내일", "오늘","어제","Tomorrow", "Today", "Yesterday" etc.
-        2. If the user uses collective expressions like "모두", "전체", "다","All", "Every", "Each" (meaning all), mark all schedules for the specified date as complete. If the user says "내일 스케줄 모두 완료로 해줘","All schedules for tomorrow", select all schedules for tomorrow.
+        2. If the user uses collective expressions like "모두", "전체", "다","All", "Every", "Each" (meaning all), perform the requested action on all schedules for the specified date. If the user says "내일 스케줄 모두 삭제해줘" or "내일 스케줄 모두 완료로 해줘", select all schedules for tomorrow.
         3. If the user specifies a particular schedule, select only that one.
-        4. If you cannot determine which schedule(s) to mark as complete, set failedToFindExactSchedule to true and give a short response asking for clarification.
-        5. If the user uses collective expressions but there are no schedules on that date, return an empty array with a response explaining that there are no schedules to complete.
+        4. Determine whether the user wants to "complete" or "delete" the schedule(s) and include this in the output.
+        5. If you cannot determine which schedule(s) to process, set failedToFindExactSchedule to true and give a short response asking for clarification.
+        6. If the user uses collective expressions but there are no schedules on that date, return an empty array with a response explaining that there are no schedules to process.
 
       ---------------------
 
       Few-shot Examples:
-      - User Query: "Mark all schedules for tomorrow as complete"
+      - User Query: "Delete all schedules for tomorrow"
         Output: [
-          { "failedToFindExactSchedule": false, "id": <first schedule id for tomorrow>, "response": "All schedules for tomorrow have been marked as complete." },
-          { "failedToFindExactSchedule": false, "id": <second schedule id for tomorrow>, "response": "All schedules for tomorrow have been marked as complete." }
+          { "failedToFindExactSchedule": false, "id": <first schedule id for tomorrow>, "action": "delete", "response": "All schedules for tomorrow have been deleted." },
+          { "failedToFindExactSchedule": false, "id": <second schedule id for tomorrow>, "action": "delete", "response": "All schedules for tomorrow have been deleted." }
         ]
       - User Query: "Mark all schedules for today as complete"
         Output: [
-          { "failedToFindExactSchedule": false, "id": <first schedule id for today>, "response": "All schedules for today have been marked as complete." },
+          { "failedToFindExactSchedule": false, "id": <first schedule id for today>, "action": "complete", "response": "All schedules for today have been marked as complete." },
           ...
         ]
-      - User Query: "Mark only the 3pm meeting for tomorrow as complete"
+      - User Query: "Delete only the 3pm meeting for tomorrow"
         Output: [
-          { "failedToFindExactSchedule": false, "id": <3pm meeting id for tomorrow>, "response": "The 3pm meeting for tomorrow has been marked as complete." }
+          { "failedToFindExactSchedule": false, "id": <3pm meeting id for tomorrow>, "action": "delete", "response": "The 3pm meeting for tomorrow has been deleted." }
         ]
       - User Query: "Mark all schedules for tomorrow as complete" (No schedules on that date)
         Output: []
@@ -350,10 +351,11 @@ export function getScheduleCompletionPrompt(userQuery, schedules){
           {
             "failedToFindExactSchedule": false,
             "id": number,
+            "action": "complete" | "delete",
             "response": "string"
           },...
         ]
-      // If multiple schedules are to be completed (e.g., with "모두", "전체", "다"), return an object for each schedule id.
+      // If multiple schedules are affected (e.g., with "모두", "전체", "다"), return an object for each schedule id.
       // If no matching schedule is found, return an empty array and a helpful message in the response.
     `;
 }

--- a/lib/tools/toolsConfig.js
+++ b/lib/tools/toolsConfig.js
@@ -130,11 +130,11 @@ const recommendScheduleConfig = {
       }
     };
 
-    const completeScheduleEventConfig = {
-      name: "complete_schedule_event",
+    const updateScheduleEventConfig = {
+      name: "update_schedule_event",
       description: `
-      Identify and mark a schedule event as completed based on the user's request. 
-      Provide the original user query and an array of event_queries to fetch candidate events. 
+      Identify the schedule event the user wants to complete or delete based on their request and perform the action.
+      Provide the original user query and an array of event_queries to fetch candidate events.
       If the correct event is unclear, the function will return failedToFindExactSchedule as true.
       `,
       parameters: {
@@ -179,7 +179,7 @@ return [
   getWeatherForecastConfig,
   addScheduleEventConfig,
   getScheduleEventsConfig,
-  completeScheduleEventConfig,
+  updateScheduleEventConfig,
   useGoogleSearchConfig,
   recommendScheduleConfig,
   updateUserProfileConfig


### PR DESCRIPTION
## Summary
- allow AI to delete schedules as well as mark them complete
- include `action` field in completion prompt output and formatters
- use `deleteEvent` when the action is `delete`
- rename `complete_schedule_event` tool and related helpers to `update_schedule_event`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c2661e7a8832cb9f4730fd8f06f96